### PR TITLE
[irods/irods#7191] Add Rocky Linux to platforms

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -52,6 +52,7 @@ def install_os_specific_dependencies():
         'Centos': install_os_specific_dependencies_yum,
         'Debian gnu_linux': install_os_specific_dependencies_apt,
         'Opensuse ': install_os_specific_dependencies_yum,
+        'Rocky linux': install_os_specific_dependencies_yum,
         'Ubuntu': install_os_specific_dependencies_apt
     }
     try:


### PR DESCRIPTION
In service of irods/irods#7191

Test hook doesn't have anything platform-specific.