### PR TITLE
[70] Do not install unittest-xml-reporting==1.14.0 (main)

### DIFF
--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -9,7 +9,6 @@ import irods_python_ci_utilities
 
 def install_test_prerequisites():
     irods_python_ci_utilities.subprocess_get_output(['sudo', 'python3', '-m', 'pip', 'install', 'boto3', '--upgrade'], check_rc=True)
-    irods_python_ci_utilities.subprocess_get_output(['sudo', '-EH', 'python3', '-m', 'pip', 'install', 'unittest-xml-reporting==1.14.0'])
 
 def main():
     parser = optparse.OptionParser()


### PR DESCRIPTION
Necessary for testing on Ubuntu24. 